### PR TITLE
[Fix] Rewrite WorkComplete Frame to Request

### DIFF
--- a/gearman-client/src/main/java/net/johnewart/gearman/client/NetworkGearmanWorker.java
+++ b/gearman-client/src/main/java/net/johnewart/gearman/client/NetworkGearmanWorker.java
@@ -11,6 +11,7 @@ import net.johnewart.gearman.common.Job;
 import net.johnewart.gearman.common.JobState;
 import net.johnewart.gearman.common.JobStatus;
 import net.johnewart.gearman.common.events.WorkEvent;
+import net.johnewart.gearman.common.packets.request.WorkCompleteRequest;
 import net.johnewart.gearman.common.packets.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,7 +97,7 @@ public class NetworkGearmanWorker implements GearmanWorker, Runnable {
                         jobConnectionMap.put(nextJob, c);
                         WorkEvent workEvent = new WorkEvent(nextJob, this);
                         result = callbacks.get(nextJob.getFunctionName()).process(workEvent);
-                        c.sendPacket(new WorkCompleteResponse(nextJob.getJobHandle(), result));
+                        c.sendPacket(new WorkCompleteRequest(nextJob.getJobHandle(), result));
                     }
 
                 } catch (IOException ioe) {

--- a/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkCompleteRequest.java
+++ b/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkCompleteRequest.java
@@ -1,0 +1,17 @@
+package net.johnewart.gearman.common.packets.request;
+
+import net.johnewart.gearman.constants.PacketType;
+
+public class WorkCompleteRequest extends WorkDataRequest {
+    public WorkCompleteRequest(String jobhandle, byte[] data)
+    {
+        super(jobhandle, data);
+        this.type = PacketType.WORK_COMPLETE;
+    }
+
+    public WorkCompleteRequest(byte[] pktdata)
+    {
+        super(pktdata);
+        this.type = PacketType.WORK_COMPLETE;
+    }
+}

--- a/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkDataRequest.java
+++ b/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkDataRequest.java
@@ -1,0 +1,52 @@
+package net.johnewart.gearman.common.packets.request;
+
+import net.johnewart.gearman.constants.PacketType;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class WorkDataRequest extends RequestPacket implements WorkRequest {
+
+    public AtomicReference<String> jobHandle;
+    public byte[] data;
+
+    public WorkDataRequest(String jobhandle, byte[] data)
+    {
+        this.jobHandle = new AtomicReference<>(jobhandle);
+        this.data = data.clone();
+        this.type = PacketType.WORK_DATA;
+    }
+
+    public WorkDataRequest(byte[] pktdata)
+    {
+        super(pktdata);
+        this.jobHandle = new AtomicReference<>();
+
+        int pOff = 0;
+        pOff = parseString(pOff, jobHandle);
+        data = Arrays.copyOfRange(rawdata, pOff, rawdata.length);
+
+    }
+
+    @Override
+    public byte[] toByteArray()
+    {
+        byte[] metadata = stringsToTerminatedByteArray(jobHandle.get());
+        return concatByteArrays(getHeader(), metadata, data);
+    }
+
+    public String getJobHandle() {
+        return jobHandle.get();
+    }
+
+    public int getPayloadSize()
+    {
+        return this.jobHandle.get().length() + 1 +
+               this.data.length;
+    }
+
+    public byte[] getData()
+    {
+        return data;
+    }
+}

--- a/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkRequest.java
+++ b/gearman-common/src/main/java/net/johnewart/gearman/common/packets/request/WorkRequest.java
@@ -1,0 +1,8 @@
+package net.johnewart.gearman.common.packets.request;
+
+import net.johnewart.gearman.constants.PacketType;
+
+public interface WorkRequest {
+    public abstract String getJobHandle();
+    public abstract PacketType getType();
+}


### PR DESCRIPTION
According to the protocol documentation and your code:

https://github.com/gearman/gearmand/blob/master/PROTOCOL#L76

https://github.com/johnewart/gearman-java/blob/12aacea06020e058b9ab071ab90c3c6f9cabd83b/gearman-common/src/main/java/net/johnewart/gearman/constants/PacketType.java#L24

WorkComplete for Worker should be Request not Response. This pull request is resolving problem with using PHP or Python clients for Java Workers. 
